### PR TITLE
Updated FeedItem_RSS::get_title()

### DIFF
--- a/classes/feeditem/rss.php
+++ b/classes/feeditem/rss.php
@@ -51,10 +51,14 @@ class FeedItem_RSS extends FeedItem_Common {
 	}
 
 	function get_title() {
-		$title = $this->elem->getElementsByTagName("title")->item(0);
+		$titles = $this->elem->getElementsByTagName("title");
 
-		if ($title) {
-			return trim($title->nodeValue);
+		foreach ($titles as $title) {
+			$nv = trim($title->nodeValue);
+
+			if (!empty($nv)) {
+				return $nv;
+			}
 		}
 	}
 

--- a/classes/feeditem/rss.php
+++ b/classes/feeditem/rss.php
@@ -51,14 +51,10 @@ class FeedItem_RSS extends FeedItem_Common {
 	}
 
 	function get_title() {
-		$titles = $this->elem->getElementsByTagName("title");
+		$title = $this->xpath->query("title", $this->elem)->item(0);
 
-		foreach ($titles as $title) {
-			$nv = trim($title->nodeValue);
-
-			if (!empty($nv)) {
-				return $nv;
-			}
+		if ($title) {
+			return trim($title->nodeValue);
 		}
 	}
 


### PR DESCRIPTION
Made the method check more thoroughly for an article title. This is an edge-case, but I have come across feeds that use multiple title tags in different name spaces; some title tags are empty while others are not. This change makes the method find the first non-empty title tag.

It shouldn't add any significant overhead but will help with some feeds.