### PR TITLE
Added a "title" attribute in the link to an article.

### DIFF
--- a/classes/feeds.php
+++ b/classes/feeds.php
@@ -580,6 +580,7 @@ class Feeds extends Handler_Protected {
 						onclick=\"return cdmClicked(event, $id);\"
 						class=\"titleWrap $hlc_suffix\">
 						<a class=\"title $hlc_suffix\"
+						title=\"".htmlspecialchars($line["title"])."\"
 						target=\"_blank\" href=\"".
 						htmlspecialchars($line["link"])."\">".
 						$line["title"] .


### PR DESCRIPTION
Added a "title" attribute in the link to an article.
Makes TTRSS more usable on a small windows, allowing to see the complete title of an article in the tooltip, without opening the article.