### PR TITLE
Add Digger, Houspets!, Broodhollow, and Kevin & Kell to af_comics

### DIFF
--- a/plugins/af_comics/filters/af_comics_comicpress.php
+++ b/plugins/af_comics/filters/af_comics_comicpress.php
@@ -3,7 +3,7 @@ class Af_Comics_ComicPress extends Af_ComicFilter {
 
 	function supported() {
 		return array("Buni", "Buttersafe", "Whomp!", "Happy Jar", "CSection",
-			"Extra Fabulous Comics");
+			"Extra Fabulous Comics", "Digger", "Housepets!", "Broodhollow");
 	}
 
 	function process(&$article) {
@@ -14,7 +14,10 @@ class Af_Comics_ComicPress extends Af_ComicFilter {
 				strpos($article["guid"], "whompcomic.com") !== FALSE ||
 				strpos($article["guid"], "extrafabulouscomics.com") !== FALSE ||
 				strpos($article["guid"], "happyjar.com") !== FALSE ||
-				strpos($article["guid"], "csectioncomics.com") !== FALSE) {
+				strpos($article["guid"], "csectioncomics.com") !== FALSE ||
+				strpos($article["guid"], "diggercomic.com") !== FALSE ||
+				strpos($article["guid"], "housepetscomic.com") !== FALSE ||
+				strpos($article["guid"], "broodhollow.chainsawsuit.com/?post_type=comic") !== FALSE) {
 
 				// lol at people who block clients by user agent
 				// oh noes my ad revenue Q_Q

--- a/plugins/af_comics/filters/af_comics_kevinandkell.php
+++ b/plugins/af_comics/filters/af_comics_kevinandkell.php
@@ -1,0 +1,37 @@
+<?php
+class Af_Comics_Kevinandkell extends Af_ComicFilter {
+
+	function supported() {
+		return array("Kevin & Kell");
+	}
+
+	function process(&$article) {
+		$owner_uid = $article["owner_uid"];
+
+		if (strpos($article["link"], "kevinandkell.com") !== FALSE) {
+
+				$res = fetch_file_contents($article["link"], false, false, false,
+					 false, false, 0,
+					 "Mozilla/5.0 (compatible; MSIE 10.0; Windows NT 6.1; WOW64; Trident/6.0)");
+
+				$doc = new DOMDocument();
+				@$doc->loadHTML($res);
+
+				$basenode = false;
+
+				if ($doc) {
+					$xpath = new DOMXPath($doc);
+					$basenode = $xpath->query('//a[@id="comicstrip"]')->item(0);
+
+					if ($basenode) {
+						$article["content"] = $doc->saveXML($basenode);
+					}
+				}
+
+			 return true;
+		}
+
+		return false;
+	}
+}
+?>


### PR DESCRIPTION
*Digger*, *Housepets!*, and *Broodhollow* are just ComicPress sites, so I added them to the whitelist in the existing filter.

*Kevin & Kell* uses a custom site, so I added a new filter file for it.