### PR TITLE
Make _DISABLE_FEED_BROWSER also disable the updateFeedBrowser RPC

### DIFF
--- a/classes/rpc.php
+++ b/classes/rpc.php
@@ -379,6 +379,8 @@ class RPC extends Handler_Protected {
 	}
 
 	function updateFeedBrowser() {
+		if (defined('_DISABLE_FEED_BROWSER') && _DISABLE_FEED_BROWSER) return;
+
 		$search = $this->dbh->escape_string($_REQUEST["search"]);
 		$limit = $this->dbh->escape_string($_REQUEST["limit"]);
 		$mode = (int) $this->dbh->escape_string($_REQUEST["mode"]);

--- a/include/feedbrowser.php
+++ b/include/feedbrowser.php
@@ -1,6 +1,8 @@
 <?php
 	function make_feed_browser($search, $limit, $mode = 1) {
 
+		if (defined('_DISABLE_FEED_BROWSER') && _DISABLE_FEED_BROWSER) return;
+
 		$owner_uid = $_SESSION["uid"];
 		$rv = '';
 


### PR DESCRIPTION
The undocumented _DISABLE_FEED_BROWSER option added in commit c39befacb29f3f709e2d248ab6d6235524d6e929 turns off the UI for looking at which feeds other users are subscribed to, but it did not prevent you from manually constructing an RPC call to get the same data. This was a privacy risk for those who consider _DISABLE_FEED_BROWSER important.