### PR TITLE
Check for HTML in the first 100 bytes.

### DIFF
--- a/include/functions2.php
+++ b/include/functions2.php
@@ -1792,7 +1792,7 @@
 	}
 
 	function is_html($content) {
-		return preg_match("/<html|DOCTYPE html/i", substr($content, 0, 20)) !== 0;
+		return preg_match("/<html|DOCTYPE html/i", substr($content, 0, 100)) !== 0;
 	}
 
 	function url_is_html($url, $login = false, $pass = false) {


### PR DESCRIPTION
Some HTML pages have an XML header (XHTML), which alone is nearly 50 bytes.
Thus we need to check for the HTML or doctype tags in the first 100 bytes.

Example URL: http://cweiske.de/tagebuch/