### PR TITLE
Performance breakthrough

### DIFF
--- a/include/functions.php
+++ b/include/functions.php
@@ -320,8 +320,7 @@
 
 		// purge orphaned posts in main content table
 		$result = db_query("DELETE FROM ttrss_entries WHERE
-			(SELECT COUNT(int_id) FROM ttrss_user_entries WHERE ref_id = id) = 0");
-
+			id NOT IN (SELECT ref_id FROM ttrss_user_entries WHERE ref_id IS NOT NULL)");
 		if ($do_output) {
 			$rows = db_affected_rows($result);
 			_debug("Purged $rows orphaned posts.");


### PR DESCRIPTION
Improvement in the Purge method for huge performance increase.
"WHERE ref_id IS NOT NULL" is needed by pgsql, not necessarily by mysql.
This is a more standard way to make deletions based on propagation (from ttrss_user_entries) with 1-to-N relations.